### PR TITLE
Set autoload parameter to true on class_exists method

### DIFF
--- a/src/MercadoPago/Entity.php
+++ b/src/MercadoPago/Entity.php
@@ -346,7 +346,7 @@ abstract class Entity
         foreach ($data as $key => $value) {
             if (is_array($value)) {
                 $className = 'MercadoPago\\' . $this->_camelize($key);
-                if (class_exists($className, false)) {
+                if (class_exists($className, true)) {
                     $entity->_setValue($key, new $className, false);
                     $entity->_fillFromArray($this->{$key}, $value);
                 } else {


### PR DESCRIPTION
On /src/MercadoPago/Entity.php   

- line 347

```php
     foreach ($data as $key => $value) {
            if (is_array($value)) {
                $className = 'MercadoPago\\' . $this->_camelize($key);
                if (class_exists($className, true)) {
                    $entity->_setValue($key, new $className, false);
                    $entity->_fillFromArray($this->{$key}, $value);
                } else {
                    $entity->_setValue($key, json_decode(json_encode($value)), false);
                }
                continue;
            }
            $entity->_setValue($key, $value, false);
        }
```