### PR TITLE
Force reset Manager query when searching an Entity

### DIFF
--- a/src/MercadoPago/Entity.php
+++ b/src/MercadoPago/Entity.php
@@ -109,6 +109,7 @@ abstract class Entity
       $entityToQuery = new $class();
       
       self::$_manager->setEntityUrl($entityToQuery, 'search');
+      self::$_manager->cleanQueryParams($entityToQuery);
       self::$_manager->setQueryParams($entityToQuery, $filters);
 
       $response = self::$_manager->execute($entityToQuery, 'get');


### PR DESCRIPTION
Necesitaba una manera de loopear sobre una lista de preferencias de pago, en busca de pagos usando las external references que tengo en la base de datos.
El problema que se me presentó es que en mi caso tengo almacenados los client id y secret de mis clientes, no los access token. Y vi que el SDK demora al inicializar utilizando estas credenciales, por lo que intenté optimizar mi código en fin de inicializar el SDK la menor cantidad de veces.

El inconveniente fue que la clase Manager mantenía el estado de la primer búsqueda luego de inicializar el SDK, por lo que todas las búsquedas las realizaba con el mismo `external_reference`. Y solo limpiaba la query al inicializar el SDK.

Analizando el funcionamiento vi que esto se podría resolver limpiando los parámetros de query de Manager al ejecutar la búsqueda.

--

Estoy escribiendo esto tarde y cansado, si no se entiende avisen y doy más detalles. Idem si hay una solución más simple 🙏 .