### PR TITLE
Añade magic method `__isset`

### DIFF
--- a/src/MercadoPago/Entity.php
+++ b/src/MercadoPago/Entity.php
@@ -220,6 +220,15 @@ abstract class Entity
     }
     /**
      * @param $name
+     *
+     * @return mixed
+     */
+    public function __isset($name)
+    {
+        return isset($this->{$name});
+    }
+    /**
+     * @param $name
      * @param $value
      *
      * @return mixed


### PR DESCRIPTION
Añade el magic method faltante `__isset` que nos permite hacer cosas como por ej:
```php
isset($payment->payer->email)
```
Más info acá: https://github.com/MercadoPagoCommunity/foro/issues/6

Créditos a @esteban-turnocheck que se dio cuenta de esto y quedamos en armar el PR