### PR TITLE
accept doctrine/anottations >=1.4 / fix future incompatibility issues with doctrine/common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": ">=5.5.0",
     "doctrine/common": ">=2.6",
-    "doctrine/annotations": "1.4.*"
+    "doctrine/annotations": ">=1.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^5",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": ">=5.5.0",
     "doctrine/common": ">=2.6",
-    "doctrine/annotations": ">=1.4"
+    "doctrine/annotations": "~1.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^5",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "doctrine/common": ">=2.6",
+    "doctrine/common": "~2.6",
     "doctrine/annotations": "~1.4"
   },
   "require-dev": {


### PR DESCRIPTION
same problem we face with doctrine/common. accepting this pull request we can keep compatibility with older versions of php without capping compatibility with newer versions. can you check this @joelibaceta ? thanks!

* Can merge in the 1.2.5 release, no compatibility issues detected.